### PR TITLE
chore: removes npmrc and updates build scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/build-config/buildspec-prod.yml
+++ b/build-config/buildspec-prod.yml
@@ -11,7 +11,7 @@ phases:
       - echo "Installing yarn Packages..."
       - yarn bootstrap
       - echo "Yarn build and publishing to NPM"
-      - npm set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+      - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
       - yarn release --no-git --no-git-release --ci 2>&1 | tee /tmp/build.log
       - grep -q 'Command failed with exit code' /tmp/build.log && exit 1
       - VERSION=$(grep '! npm version' /tmp/build.log | awk '{ print $4 }')


### PR DESCRIPTION
Removes .npmrc file which required that a NPM_TOKEN be present in the environment variables.
This caused error when a new developer clones it for the first time.
Since the token is required only during publishing, moved the config to the CI build scripts.