### PR TITLE
chore: changes ios deployment target to 11.2 to match Chargebee iOS 

### DIFF
--- a/ChargebeeReactNative.podspec
+++ b/ChargebeeReactNative.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "11.2" }
   s.source       = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
Ref: https://github.com/chargebee/chargebee-ios/blob/master/Chargebee.podspec