### PR TITLE
Fixes android release issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Create PR for package.json and changelogs
         run: | 
           VERSION=$(cat package.json | jq -r '.version')
-          gh pr create -B master -H docs-v${VERSION} --title 'Update post release docs into ${{ env.BRANCH_NAME }} ' --body 'Created by Github action'
+          gh pr create -B ${{ env.BRANCH_NAME }} -H docs-v${VERSION} --title 'Update post release docs into ${{ env.BRANCH_NAME }} ' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.chargebee.android">
+          package="com.chargebee.android.reactnative">
 
 </manifest>

--- a/android/src/main/java/com/chargebee/android/reactnative/ChargebeeReactNativeModule.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/ChargebeeReactNativeModule.kt
@@ -1,5 +1,8 @@
-package com.chargebee.android
+package com.chargebee.android.reactnative
 
+import com.chargebee.android.Chargebee
+import com.chargebee.android.reactnative.ChargebeeReactNativeSpec
+import com.chargebee.android.ErrorDetail
 import com.chargebee.android.billingservice.CBCallback
 import com.chargebee.android.billingservice.CBPurchase
 import com.chargebee.android.billingservice.GPErrorCode
@@ -8,7 +11,15 @@ import com.chargebee.android.exceptions.CBProductIDResult
 import com.chargebee.android.exceptions.ChargebeeResult
 import com.chargebee.android.models.*
 import com.chargebee.android.network.ReceiptDetail
-import com.chargebee.android.utils.*
+import com.chargebee.android.reactnative.models.*
+import com.chargebee.android.reactnative.utils.convertArrayToWritableArray
+import com.chargebee.android.reactnative.utils.convertAuthenticationDetailToDictionary
+import com.chargebee.android.reactnative.utils.convertListToWritableArray
+import com.chargebee.android.reactnative.utils.convertPurchaseResultToDictionary
+import com.chargebee.android.reactnative.utils.convertQueryParamsToArray
+import com.chargebee.android.reactnative.utils.convertReadableArray
+import com.chargebee.android.reactnative.utils.convertReadableMapToCustomer
+import com.chargebee.android.reactnative.utils.convertSubscriptionsToDictionary
 import com.facebook.react.bridge.*
 
 class ChargebeeReactNativeModule internal constructor(context: ReactApplicationContext) :
@@ -34,7 +45,12 @@ class ChargebeeReactNativeModule internal constructor(context: ReactApplicationC
         }
         is ChargebeeResult.Error -> {
           val messageUserInfo = it.exp.messageUserInfo()
-          promise.reject("${CBReactNativeError.INVALID_SDK_CONFIGURATION.code}", messageUserInfo.getString("message"), it.exp, messageUserInfo)
+          promise.reject(
+            "${CBReactNativeError.INVALID_SDK_CONFIGURATION.code}",
+            messageUserInfo.getString("message"),
+            it.exp,
+            messageUserInfo
+          )
         }
       }
     }
@@ -125,14 +141,19 @@ class ChargebeeReactNativeModule internal constructor(context: ReactApplicationC
   @ReactMethod
   override fun retrieveSubscriptions(queryParams: ReadableMap, promise: Promise) {
     Chargebee.retrieveSubscriptions(queryParams.toMap()) {
-      when(it){
+      when (it) {
         is ChargebeeResult.Success -> {
           val subscriptions = (it.data as CBSubscription).list
           promise.resolve(convertSubscriptionsToDictionary(subscriptions))
         }
-        is ChargebeeResult.Error ->{
+        is ChargebeeResult.Error -> {
           val messageUserInfo = it.exp.messageUserInfo()
-          promise.reject("${CBReactNativeError.INVALID_SDK_CONFIGURATION.code}", messageUserInfo.getString("message"), it.exp, messageUserInfo)
+          promise.reject(
+            "${CBReactNativeError.INVALID_SDK_CONFIGURATION.code}",
+            messageUserInfo.getString("message"),
+            it.exp,
+            messageUserInfo
+          )
         }
       }
     }

--- a/android/src/main/java/com/chargebee/android/reactnative/ChargebeeReactNativePackage.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/ChargebeeReactNativePackage.kt
@@ -1,5 +1,6 @@
-package com.chargebee.android
+package com.chargebee.android.reactnative
 
+import com.chargebee.android.reactnative.BuildConfig
 import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.NativeModule

--- a/android/src/main/java/com/chargebee/android/reactnative/models/CBExceptionExtensions.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/models/CBExceptionExtensions.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android.models
+package com.chargebee.android.reactnative.models
 
 import com.chargebee.android.exceptions.CBException
 import com.facebook.react.bridge.WritableMap

--- a/android/src/main/java/com/chargebee/android/reactnative/models/CBReactNativeError.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/models/CBReactNativeError.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android.models
+package com.chargebee.android.reactnative.models
 
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode.*

--- a/android/src/main/java/com/chargebee/android/reactnative/models/PurchaseResult.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/models/PurchaseResult.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android.models
+package com.chargebee.android.reactnative.models
 
 import com.chargebee.android.network.ReceiptDetail
 import java.io.Serializable

--- a/android/src/main/java/com/chargebee/android/reactnative/models/ReadableMapExtension.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/models/ReadableMapExtension.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android.models
+package com.chargebee.android.reactnative.models
 
 import com.facebook.react.bridge.ReadableMap
 

--- a/android/src/main/java/com/chargebee/android/reactnative/utils/Converter.kt
+++ b/android/src/main/java/com/chargebee/android/reactnative/utils/Converter.kt
@@ -1,7 +1,7 @@
-package com.chargebee.android.utils
+package com.chargebee.android.reactnative.utils
 
 import com.chargebee.android.models.CBProduct
-import com.chargebee.android.models.PurchaseResult
+import com.chargebee.android.reactnative.models.PurchaseResult
 import com.chargebee.android.models.SubscriptionDetailsWrapper
 import com.chargebee.android.network.CBAuthResponse
 import com.chargebee.android.network.CBCustomer

--- a/android/src/newarch/ChargebeeReactNativeSpec.kt
+++ b/android/src/newarch/ChargebeeReactNativeSpec.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android
+package com.chargebee.android.reactnative
 
 import com.facebook.react.bridge.ReactApplicationContext
 

--- a/android/src/oldarch/ChargebeeReactNativeSpec.kt
+++ b/android/src/oldarch/ChargebeeReactNativeSpec.kt
@@ -1,4 +1,4 @@
-package com.chargebee.android
+package com.chargebee.android.reactnative
 
 import com.facebook.react.bridge.*
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "hooks": {
       "after:git:afterRelease": [
         "git checkout -b docs-v${version}",
-        "git push origin docs-v${version}"
+        "git push origin docs-v${version}",
+        "git push origin v${version}"
       ]
     },
     "npm": {


### PR DESCRIPTION
Issue description: 
When the release build was triggered, the BuildConfig file is auto-generated. Since the Chargebee Android SDK is an internal dependency, 2 BuildConfig files are created in the same package, causing conflicts.
Fix:
- Renames the package of android reactnative components to avoid conflicting with that from Chargebee Android SDK