### PR TITLE
fix: remove offset in Chargebee.retrieveProductIdentifiers example

### DIFF
--- a/example/src/screens/PurchasesScreen.tsx
+++ b/example/src/screens/PurchasesScreen.tsx
@@ -23,7 +23,6 @@ const PurchasesScreen = ({ navigation, customerId }) => {
   async function fetchProductIdentifiers() {
     const queryParams: ProductIdentifiersRequest = {
       limit: '10',
-      offset: '1',
     };
     try {
       console.log('Fetching products');


### PR DESCRIPTION
Hello guys, 
I noticed that the offset parameter in the method `Chargebee.retrieveProductIdentifiers` set from 1-st page, but it may confuse if you have < 10 subs, because **offest starts from 0** .
So the method will return empty list, so I just have removed this param, I think it will be clearer.

