### PR TITLE
feat: expose showManageSubscriptionsSettings to React Native on iOS side

### DIFF
--- a/ios/ChargebeeHelper.swift
+++ b/ios/ChargebeeHelper.swift
@@ -286,6 +286,10 @@ public class ChargebeeHelper: NSObject {
             }
         }
     }
+
+    @objc public func showManageSubscriptionsSettings() {
+        Chargebee.shared.showManageSubscriptionsSettings()
+    }
 }
 
 private func convertStringToProductType(productTypeString: String)-> ProductType{

--- a/ios/ChargebeeReactNative.mm
+++ b/ios/ChargebeeReactNative.mm
@@ -102,6 +102,12 @@ RCT_REMAP_METHOD(retrieveEntitlements,
     [helper retrieveEntitlementsWithEntitlementsRequest:entitlementsRequest resolver:resolve rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(showManageSubscriptionsSettings)
+{
+    ChargebeeHelper *helper = [ChargebeeHelper shared];
+    [helper showManageSubscriptionsSettings];
+}
+
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/src/Chargebee.ts
+++ b/src/Chargebee.ts
@@ -205,4 +205,11 @@ export default class Chargebee {
   ): Promise<Array<Entitlement>> {
     return ChargebeeReactNative.retrieveEntitlements(entitlementsRequest);
   }
+
+  /**
+   * Opens modal modal to manage subscriptions.
+   */
+  public static showManageSubscriptionsSettings() {
+    ChargebeeReactNative.showManageSubscriptionsSettings();
+  }
 }

--- a/src/NativeChargebeeReactNative.ts
+++ b/src/NativeChargebeeReactNative.ts
@@ -38,6 +38,7 @@ export interface Spec extends TurboModule {
   retrieveEntitlements(
     entitlementsRequest: Object
   ): Promise<Array<Entitlement>>;
+  showManageSubscriptionsSettings(): void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('ChargebeeReactNative');

--- a/src/__mocks__/setupJest.ts
+++ b/src/__mocks__/setupJest.ts
@@ -11,4 +11,5 @@ NativeModules.ChargebeeReactNative = {
   retrieveEntitlements: jest.fn(),
   purchaseNonSubscriptionProduct: jest.fn(),
   validateReceiptForNonSubscriptions: jest.fn(),
+  showManageSubscriptionsSettings: jest.fn(),
 };

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -226,4 +226,12 @@ describe('Chargebee React Native', () => {
       NativeModules.ChargebeeReactNative.validateReceiptForNonSubscriptions
     ).toHaveBeenCalledWith(productId, productType, customer);
   });
+
+  it('show Manage Subscriptions Settings', () => {
+    Chargebee.showManageSubscriptionsSettings();
+
+    expect(
+      NativeModules.ChargebeeReactNative.showManageSubscriptionsSettings
+    ).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Exposes the `showManageSubscriptionsSettings ` for the iOS side in React native as well. I could probably do the Android side in a separate PR (not that familiar with Kotlin and will take a bit to set up the dev environment for it) if that sounds like an alright plan?