### PR TITLE
Update Billing Client & Chargebee Android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,8 +84,8 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.chargebee:chargebee-android:1.2.2'
-  implementation 'com.android.billingclient:billing-ktx:6.2.1'
+  implementation 'com.chargebee:chargebee-android:1.2.4'
+  implementation 'com.android.billingclient:billing-ktx:7.1.1'
   implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ChargebeeReactNative_kotlinVersion=1.9.0
+ChargebeeReactNative_kotlinVersion=1.10.0
 ChargebeeReactNative_minSdkVersion=21
 ChargebeeReactNative_targetSdkVersion=31
 ChargebeeReactNative_compileSdkVersion=31


### PR DESCRIPTION
**Upgraded Billing Client Lib**

### Changes
- Upgraded below package versions
  - Billing Client (v6.2.1 -> v7.1.1)
  - Chargebee Android (v1.2.2 -> 1.2.4)

