### PR TITLE
Update Billing Client & Chargebee Android version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [!NOTE]  
 > #### Updates for Billing Library 6
-> - SDK Version 3.0: This version includes Google Billing Library 6.2.1 but uses Google Billing Library 5.2.1 APIs to fetch product information from the Google Play Console and make purchases. If you’re integrating Chargebee’s SDK for the first time, then use this version, and if you’re migrating from the older version of SDK to this version, follow the migration steps in this [document](https://www.chargebee.com/docs/2.0/mobile-playstore-billing-library-5.html).
+> - SDK Version 3.0: This version includes Google Billing Library 7.1.1 but uses Google Billing Library 5.2.1 APIs to fetch product information from the Google Play Console and make purchases. If you’re integrating Chargebee’s SDK for the first time, then use this version, and if you’re migrating from the older version of SDK to this version, follow the migration steps in this [document](https://www.chargebee.com/docs/2.0/mobile-playstore-billing-library-5.html).
 > - SDK Version 2.4.4: This [version](https://github.com/chargebee/chargebee-react-native/tree/master) includes Billing Library 6.2.1 but still uses Billing Library 4.0 APIs to fetch product information from the Google Play Console and make purchases. This will enable you to list or update your Android app on the store without any warnings from Google and give you enough time to migrate to version 2.0.
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,8 +84,8 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.chargebee:chargebee-android:2.0.0-beta-4'
-  implementation 'com.android.billingclient:billing-ktx:6.2.1'
+  implementation 'com.chargebee:chargebee-android:2.0.0-beta-5'
+  implementation 'com.android.billingclient:billing-ktx:7.1.1'
   implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ChargebeeReactNative_kotlinVersion=1.9.0
+ChargebeeReactNative_kotlinVersion=1.10.0
 ChargebeeReactNative_minSdkVersion=21
 ChargebeeReactNative_targetSdkVersion=31
 ChargebeeReactNative_compileSdkVersion=31


### PR DESCRIPTION
**Upgraded Billing Client Lib**

### Changes
- Upgraded below package versions
  - Billing Client (v6.2.1 -> v7.1.1)
  - Chargebee Android (v2.0.0-beta-4 -> v2.0.0-beta-5)

