### PR TITLE
updated cache action version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,20 +40,20 @@ jobs:
             npm config set //registry.npmjs.com/:_authToken=$NPM_TOKEN
             npm config list
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
       - name: Yarn Tests
         run: yarn test
       - name: Pre-Release package
         if: github.ref == 'refs/heads/next'
         run: npm run release -- --ci --preRelease=beta -VV
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release package
         if: github.ref == 'refs/heads/master'
         run: npm run release -- --ci -VV
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
       - name: Create PR for package.json and changelogs
         run: | 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the caching action for node modules.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24): Updated the `actions/cache` action from version `v2` to `v4` in the "Cache node modules" step.