### PR TITLE
updated npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,20 +44,20 @@ jobs:
             npm config set //registry.npmjs.com/:_authToken=$NPM_TOKEN
             npm config list
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
       - name: Yarn Tests
         run: yarn test
       - name: Pre-Release package
         if: github.ref == 'refs/heads/next'
         run: npm run release -- --ci --preRelease=beta -VV
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release package
         if: github.ref == 'refs/heads/master'
         run: npm run release -- --ci -VV 
         env: 
-          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_1 }}
+          NPM_TOKEN: ${{ secrets.RN_SDK_NPM_WRITE_TOKEN_2 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
       - name: Create PR for package.json and changelogs
         run: | 


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to use a new NPM authentication token for publishing packages. The change ensures the workflow uses the updated `RN_SDK_NPM_WRITE_TOKEN_2` secret instead of the previous `RN_SDK_NPM_WRITE_TOKEN_1`.